### PR TITLE
Adds a field to add descripiton for approvaltask

### DIFF
--- a/pkg/apis/approvaltask/v1alpha1/approvaltask_types.go
+++ b/pkg/apis/approvaltask/v1alpha1/approvaltask_types.go
@@ -43,6 +43,7 @@ type ApprovalTask struct {
 type ApprovalTaskSpec struct {
 	Approvers                 []ApproverDetails `json:"approvers"`
 	NumberOfApprovalsRequired int               `json:"numberOfApprovalsRequired"`
+	Description               string            `json:"description,omitempty"`
 }
 
 type ApproverDetails struct {

--- a/pkg/reconciler/approvaltask/approvaltask.go
+++ b/pkg/reconciler/approvaltask/approvaltask.go
@@ -58,6 +58,7 @@ const (
 	hasRejected       = "reject"
 	allApprovers      = "approvers"
 	approvalsRequired = "numberOfApprovalsRequired"
+	description       = "description"
 
 	// CustomRunLabelKey is used as the label identifier for a ApprovalTask
 	CustomRunLabelKey = "tekton.dev/customRun"

--- a/pkg/reconciler/approvaltask/utils.go
+++ b/pkg/reconciler/approvaltask/utils.go
@@ -163,6 +163,7 @@ func createApprovalTask(ctx context.Context, approvaltaskClientSet versioned.Int
 	var (
 		approvers      []v1alpha1.ApproverDetails
 		users          []string
+		desc           string
 		err            error
 		approverExists = make(map[string]bool)
 		userExists     = make(map[string]bool)
@@ -194,6 +195,8 @@ func createApprovalTask(ctx context.Context, approvaltaskClientSet versioned.Int
 				return v1alpha1.ApprovalTask{}, err
 			}
 			numberOfApprovalsRequired = tempApproversRequired
+		} else if v.Name == description {
+			desc = v.Value.StringVal
 		}
 	}
 
@@ -214,6 +217,7 @@ func createApprovalTask(ctx context.Context, approvaltaskClientSet versioned.Int
 		Spec: v1alpha1.ApprovalTaskSpec{
 			Approvers:                 approvers,
 			NumberOfApprovalsRequired: numberOfApprovalsRequired,
+			Description:               desc,
 		},
 	}
 


### PR DESCRIPTION
* User can now add description for the approvaltask in the params of 
pipelinerun/customrun in the same way approvers and number of 
approvals required are added

Signed-off-by: PuneetPunamiya <ppunamiy@redhat.com>
