### PR TITLE
Fix approvalState value to `rejected` instead of false

### DIFF
--- a/pkg/reconciler/approvaltask/approvaltask.go
+++ b/pkg/reconciler/approvaltask/approvaltask.go
@@ -188,7 +188,7 @@ func (r *Reconciler) reconcile(ctx context.Context, run *v1beta1.CustomRun, stat
 		timeout = &metav1.Duration{Duration: time.Duration(60) * time.Minute}
 	}
 	if approvalTask.ApprovalTaskHasTimedOut(ctx, r.clock, timeout.Duration) {
-		approvalTask.Status.State = "false"
+		approvalTask.Status.State = rejectedState
 		_, err := r.approvaltaskClientSet.OpenshiftpipelinesV1alpha1().ApprovalTasks(approvalTask.Namespace).UpdateStatus(ctx, approvalTask, metav1.UpdateOptions{})
 		if err != nil {
 			return err


### PR DESCRIPTION
 * Initially the approvalState value was set to `false` if timeout was reached, but it should be set to `rejected`, hence this patch fixes this