### PR TITLE
Fixes webhook config file

### DIFF
--- a/config/openshift/400-webhook-controller.yaml
+++ b/config/openshift/400-webhook-controller.yaml
@@ -21,7 +21,7 @@ metadata:
 
 ---
 apiVersion: admissionregistration.k8s.io/v1
-kind: MutatingWebhookConfiguration
+kind: ValidatingWebhookConfiguration
 metadata:
   name: webhook.manual.approval.dev
 webhooks:


### PR DESCRIPTION
- Mutating webhook was created when manual approval was installed on openshift cluster, hence the webhook pod was not getting the request

- Hence this patch fixes the config file to create validating webhook instead of mutating webhook