### PR TITLE
[Openshift] Adds `delete` and `create` verbs to validating webhook

### DIFF
--- a/config/openshift/201-clusterrole.yaml
+++ b/config/openshift/201-clusterrole.yaml
@@ -93,7 +93,7 @@ rules:
     resourceNames: ["webhook.manual.approval.dev"]
     # When there are changes to the configs or secrets, knative updates the validatingwebhook config
     # with the updated certificates or the refreshed set of rules.
-    verbs: ["get", "list", "update", "patch", "watch"]
+    verbs: ["get", "list", "update", "patch", "watch", "delete", "create"]
   - apiGroups: [ "openshift-pipelines.org" ]
     resources: [ "approvaltasks" ]
     verbs: [ "get", "list", "create", "update", "delete", "patch", "watch" ]


### PR DESCRIPTION
- When manual approval is shiped in operator, webhook gives an error as it cannot set an ownerRef on a resource which it can't delete

- Hence this patch fixes this by adding missing verbs