### PR TITLE
Add KUBERNETES_MIN_VERSION env to override k8s variable

### DIFF
--- a/config/kubernetes/500-controller.yaml
+++ b/config/kubernetes/500-controller.yaml
@@ -68,6 +68,8 @@ spec:
           value: config-observability
         - name: METRICS_DOMAIN
           value: openshift-pipelines.org/manual-approval-gate
+        - name: KUBERNETES_MIN_VERSION
+          value: "v1.28.0"
         securityContext:
           seccompProfile:
             type: RuntimeDefault

--- a/config/kubernetes/500-webhook.yaml
+++ b/config/kubernetes/500-webhook.yaml
@@ -45,6 +45,8 @@ spec:
               value: manual-approval-gate-webhook-certs
             - name: CONFIG_LEADERELECTION_NAME
               value: manual-approval-config-leader-election
+            - name: KUBERNETES_MIN_VERSION
+              value: "v1.28.0"
           ports:
             - name: https-webhook
               containerPort: 8443

--- a/config/openshift/500-controller.yaml
+++ b/config/openshift/500-controller.yaml
@@ -68,6 +68,8 @@ spec:
           value: config-observability
         - name: METRICS_DOMAIN
           value: openshift-pipelines.org/manual-approval-gate
+        - name: KUBERNETES_MIN_VERSION
+          value: "v1.28.0"
         securityContext:
           seccompProfile:
             type: RuntimeDefault

--- a/config/openshift/500-webhook.yaml
+++ b/config/openshift/500-webhook.yaml
@@ -45,6 +45,8 @@ spec:
               value: manual-approval-gate-webhook-certs
             - name: CONFIG_LEADERELECTION_NAME
               value: manual-approval-config-leader-election
+            - name: KUBERNETES_MIN_VERSION
+              value: "v1.28.0"
           ports:
             - name: https-webhook
               containerPort: 8443


### PR DESCRIPTION
<!-- 🎉⛓🎉 Thank you for the PR!!! 🎉⛓🎉 -->

# Changes

Added an environment variable `KUBERNETES_MIN_VERSION` in the deployment YAML file to enforce compatibility with Kubernetes v1.28.0 or higher.
