### PR TITLE
config: set readOnlyRootFilesystem on all containers

### DIFF
--- a/config/kubernetes/500-controller.yaml
+++ b/config/kubernetes/500-controller.yaml
@@ -75,6 +75,7 @@ spec:
             type: RuntimeDefault
           runAsNonRoot: true
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           runAsUser: 65532
           capabilities:
             drop:

--- a/config/kubernetes/500-webhook.yaml
+++ b/config/kubernetes/500-webhook.yaml
@@ -55,6 +55,7 @@ spec:
               type: RuntimeDefault
             runAsNonRoot: true
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             runAsUser: 65532
             capabilities:
               drop:

--- a/config/openshift/500-controller.yaml
+++ b/config/openshift/500-controller.yaml
@@ -75,6 +75,7 @@ spec:
             type: RuntimeDefault
           # runAsNonRoot: true
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           # runAsUser: 65532
           capabilities:
             drop:

--- a/config/openshift/500-webhook.yaml
+++ b/config/openshift/500-webhook.yaml
@@ -55,6 +55,7 @@ spec:
               type: RuntimeDefault
             # runAsNonRoot: true
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             # runAsUser: 65532
             capabilities:
               drop:


### PR DESCRIPTION
`readOnlyRootFilesystem` will keep you from writing anywhere other
than a mounted volume. It's not just the root directory but the entire
root filesystem.

It's a security best practice that we should embrace in all the Tekton
components.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
