### PR TITLE
fix: Prevent duplicate approval entries when user is both individual approver and group member

### DIFF
--- a/pkg/actions/actions.go
+++ b/pkg/actions/actions.go
@@ -89,7 +89,7 @@ func Update(gr schema.GroupVersionResource, c *cli.Clients, opts *cli.Options) e
 	}
 
 	if !containsUsername(at.Spec.Approvers, opts) {
-		return fmt.Errorf("Approver: %s, is not present in the approvers list", opts.Username)
+		return fmt.Errorf("approver: %s, is not present in the approvers list", opts.Username)
 	}
 
 	if err := update(gvr, c.Dynamic, at, opts); err != nil {
@@ -100,51 +100,53 @@ func Update(gr schema.GroupVersionResource, c *cli.Clients, opts *cli.Options) e
 }
 
 func update(gvr *schema.GroupVersionResource, dynamic dynamic.Interface, at *v1alpha1.ApprovalTask, opts *cli.Options) error {
+	// Track if user has been processed as individual User type to avoid duplicate processing
+	userProcessedAsIndividual := false
+
+	// First pass: Process all User type approvers to ensure User type takes precedence
 	for i, approver := range at.Spec.Approvers {
-		switch v1alpha1.DefaultedApproverType(approver.Type) {
-		case "User":
-			if approver.Name == opts.Username {
-				// return true
-				at.Spec.Approvers[i].Input = opts.Input
-				if opts.Message != "" {
-					at.Spec.Approvers[i].Message = opts.Message
-				}
+		if v1alpha1.DefaultedApproverType(approver.Type) == "User" && approver.Name == opts.Username {
+			at.Spec.Approvers[i].Input = opts.Input
+			if opts.Message != "" {
+				at.Spec.Approvers[i].Message = opts.Message
 			}
-		case "Group":
+			userProcessedAsIndividual = true
+		}
+	}
+
+	// Second pass: Process Group type approvers, but only add user to group if not already processed as individual
+	for i, approver := range at.Spec.Approvers {
+		if v1alpha1.DefaultedApproverType(approver.Type) == "Group" {
 			for _, groupName := range opts.Groups {
 				if approver.Name == groupName {
-					// return true
 					at.Spec.Approvers[i].Input = opts.Input
 					if opts.Message != "" {
 						at.Spec.Approvers[i].Message = opts.Message
 					}
 
-					userExists := false
+					// Only add user to group members if they haven't been processed as individual User
+					// This prevents duplicate entries when user is both individual approver and group member
+					if !userProcessedAsIndividual {
+						userExists := false
 
-					for j, existing := range at.Spec.Approvers[i].Users {
-						if existing.Name == opts.Username {
-							userExists = true
-							if existing.Input != opts.Input {
-								at.Spec.Approvers[i].Users[j].Input = opts.Input
+						for j, existing := range at.Spec.Approvers[i].Users {
+							if existing.Name == opts.Username {
+								userExists = true
+								if existing.Input != opts.Input {
+									at.Spec.Approvers[i].Users[j].Input = opts.Input
+								}
+								break
 							}
-							break
 						}
-					}
-					if !userExists {
-						newUser := v1alpha1.UserDetails{
-							Name:  opts.Username,
-							Input: opts.Input,
+						if !userExists {
+							newUser := v1alpha1.UserDetails{
+								Name:  opts.Username,
+								Input: opts.Input,
+							}
+							at.Spec.Approvers[i].Users = append(at.Spec.Approvers[i].Users, newUser)
 						}
-						at.Spec.Approvers[i].Users = append(at.Spec.Approvers[i].Users, newUser)
 					}
 				}
-			}
-		}
-
-		if approver.Name == opts.Username {
-			at.Spec.Approvers[i].Input = opts.Input
-			if opts.Message != "" {
-				at.Spec.Approvers[i].Message = opts.Message
 			}
 		}
 	}

--- a/pkg/cli/cmd/approve/approve_test.go
+++ b/pkg/cli/cmd/approve/approve_test.go
@@ -200,7 +200,7 @@ func TestApproveApprovalTask(t *testing.T) {
 			name:           "invalid username",
 			command:        command(t, approvaltasks, ns, dc, "test-user", []string{}),
 			args:           []string{"at-2", "-n", "foo"},
-			expectedOutput: "Error: failed to approve approvalTask from namespace foo: Approver: test-user, is not present in the approvers list\n",
+			expectedOutput: "Error: failed to approve approvalTask from namespace foo: approver: test-user, is not present in the approvers list\n",
 			wantError:      true,
 		},
 		{
@@ -222,7 +222,7 @@ func TestApproveApprovalTask(t *testing.T) {
 			name:           "user not in any required groups",
 			command:        command(t, approvaltasks, ns, dc, "charlie", []string{"other-group"}),
 			args:           []string{"at-group-1", "-n", "foo"},
-			expectedOutput: "Error: failed to approve approvalTask from namespace foo: Approver: charlie, is not present in the approvers list\n",
+			expectedOutput: "Error: failed to approve approvalTask from namespace foo: approver: charlie, is not present in the approvers list\n",
 			wantError:      true,
 		},
 		{

--- a/pkg/cli/cmd/reject/reject_test.go
+++ b/pkg/cli/cmd/reject/reject_test.go
@@ -200,7 +200,7 @@ func TestRejectApprovalTask(t *testing.T) {
 			name:           "invalid username",
 			command:        command(t, approvaltasks, ns, dc, "test-user", []string{}),
 			args:           []string{"at-2", "-n", "foo"},
-			expectedOutput: "Error: failed to reject approvalTask from namespace foo: Approver: test-user, is not present in the approvers list\n",
+			expectedOutput: "Error: failed to reject approvalTask from namespace foo: approver: test-user, is not present in the approvers list\n",
 			wantError:      true,
 		},
 		{
@@ -222,7 +222,7 @@ func TestRejectApprovalTask(t *testing.T) {
 			name:           "user not in any required groups",
 			command:        command(t, approvaltasks, ns, dc, "charlie", []string{"other-group"}),
 			args:           []string{"at-group-1", "-n", "foo"},
-			expectedOutput: "Error: failed to reject approvalTask from namespace foo: Approver: charlie, is not present in the approvers list\n",
+			expectedOutput: "Error: failed to reject approvalTask from namespace foo: approver: charlie, is not present in the approvers list\n",
 			wantError:      true,
 		},
 		{


### PR DESCRIPTION
- When a user is listed as both an individual approver and a member of an approving group, their approval was being recorded twice - once in the User section and again in the Group's members section.

- This fix prioritizes User-type approvers over Group membership to ensure each user's approval is only recorded once in the status response.

- Resolves duplicate entries in approversResponse status field.