### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for manual-approval-gate-1-19-controller

### DIFF
--- a/.konflux/dockerfiles/controller.Dockerfile
+++ b/.konflux/dockerfiles/controller.Dockerfile
@@ -23,8 +23,9 @@ COPY --from=builder /tmp/HEAD ${KO_DATA_PATH}/HEAD
 
 LABEL \
     com.redhat.component="openshift-pipelines-manual-approval-gate-rhel9-container" \
-    name="openshift-pipelines/pipelines-manual-approval-gate-rhel9" \
+    name="openshift-pipelines/pipelines-manual-approval-gate-controller-rhel9" \
     version=$VERSION \
+    cpe="cpe:/a:redhat:openshift_pipelines:1.19::el9" \
     summary="Red Hat OpenShift Pipelines Manual Approval Gate" \
     maintainer="pipelines-extcomm@redhat.com" \
     description="Red Hat OpenShift Pipelines Manual Approval Gate" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
