### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for manual-approval-gate-1-18-webhook

### DIFF
--- a/.konflux/dockerfiles/webhook.Dockerfile
+++ b/.konflux/dockerfiles/webhook.Dockerfile
@@ -21,7 +21,8 @@ COPY --from=builder /tmp/manual-approval-gate-webhook ${KO_APP}/manual-approval-
 
 LABEL \
     com.redhat.component="openshift-pipelines-manual-approval-gate-rhel9-container" \
-    name="openshift-pipelines/pipelines-manual-approval-gate-rhel9" \
+    name="openshift-pipelines/pipelines-manual-approval-gate-webhook-rhel9" \
+    cpe="cpe:/a:redhat:openshift_pipelines:1.18::el9" \
     version=$VERSION \
     summary="Red Hat OpenShift Pipelines Manual Approval Gate" \
     maintainer="pipelines-extcomm@redhat.com" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
