### PR TITLE
Bump VERSION label to 1.15.4

### DIFF
--- a/.konflux/dockerfiles/controller.Dockerfile
+++ b/.konflux/dockerfiles/controller.Dockerfile
@@ -12,7 +12,7 @@ RUN go build -ldflags="-X 'knative.dev/pkg/changeset.rev=$(cat /tmp/HEAD)'" -mod
     ./cmd/controller
 
 FROM $RUNTIME
-ARG VERSION=manual-approval-gate-controller-1.15.3
+ARG VERSION=manual-approval-gate-controller-1.15.4
 
 ENV KO_APP=/ko-app \
     KO_DATA_PATH=/kodata

--- a/.konflux/dockerfiles/webhook.Dockerfile
+++ b/.konflux/dockerfiles/webhook.Dockerfile
@@ -12,7 +12,7 @@ RUN go build -ldflags="-X 'knative.dev/pkg/changeset.rev=$(cat /tmp/HEAD)'" -mod
     ./cmd/webhook
 
 FROM $RUNTIME
-ARG VERSION=manual-approval-gate-webhook-1.15.3
+ARG VERSION=manual-approval-gate-webhook-1.15.4
 
 ENV KO_APP=/ko-app
 


### PR DESCRIPTION
Bump ARG VERSION from 1.15.3 to 1.15.4 in controller and webhook Dockerfiles.