### PR TITLE
[Release-v1.21.x] Fix CVE-2026-33211: bump tektoncd/pipeline to v1.0.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/openshift-pipelines/manual-approval-gate
 
-go 1.23.0
-
-toolchain go1.23.8
+go 1.24.0
 
 require (
 	github.com/fatih/color v1.18.0
@@ -13,7 +11,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.10.0
-	github.com/tektoncd/pipeline v1.0.0
+	github.com/tektoncd/pipeline v1.0.2
 	github.com/tektoncd/plumbing v0.0.0-20221005220331-b2ddcdddc5e7
 	go.uber.org/zap v1.27.0
 	gomodules.xyz/jsonpatch/v2 v2.5.0

--- a/go.sum
+++ b/go.sum
@@ -903,8 +903,8 @@ github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
-github.com/tektoncd/pipeline v1.0.0 h1:qq/BtjwtvZV7qhd6BnL5sGoBM4vVqpCtz/+hMbs6p94=
-github.com/tektoncd/pipeline v1.0.0/go.mod h1:4XV9M4YrbCmsI4yDePcc5V8SM0Uso+S+0km80/dTD1I=
+github.com/tektoncd/pipeline v1.0.2 h1:WBvXquuTxDS1feNnTJ8uKuCEBzvRMTPkRa8cmXAMyk4=
+github.com/tektoncd/pipeline v1.0.2/go.mod h1:CbqDSVgytHYm6T3UYz/NQYmzKOv18sD/hNh06CYw77o=
 github.com/tektoncd/plumbing v0.0.0-20221005220331-b2ddcdddc5e7 h1:N9npo779eqTDXEjqcwVkwdS9rhHe+dkcfzhKp97zJfs=
 github.com/tektoncd/plumbing v0.0.0-20221005220331-b2ddcdddc5e7/go.mod h1:uJBaI0AL/kjPThiMYZcWRujEz7D401v643d6s/21GAg=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1/openapi_generated.go
@@ -2400,7 +2400,7 @@ func schema_pkg_apis_pipeline_v1_RefSource(ref common.ReferenceCallback) common.
 					},
 					"entryPoint": {
 						SchemaProps: spec.SchemaProps{
-							Description: "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.8/git-clone.yaml\"",
+							Description: "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.10/git-clone.yaml\"",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1/pipelinerun_validation.go
+++ b/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1/pipelinerun_validation.go
@@ -131,26 +131,41 @@ func (ps *PipelineRunSpec) Validate(ctx context.Context) (errs *apis.FieldError)
 // ValidateUpdate validates the update of a PipelineRunSpec
 func (ps *PipelineRunSpec) ValidateUpdate(ctx context.Context) (errs *apis.FieldError) {
 	if !apis.IsInUpdate(ctx) {
-		return
+		return errs
 	}
 	oldObj, ok := apis.GetBaseline(ctx).(*PipelineRun)
 	if !ok || oldObj == nil {
-		return
+		return errs
 	}
-	old := &oldObj.Spec
+	if oldObj.IsDone() {
+		// try comparing without any copying first
+		// this handles the common case where only finalizers changed
+		if equality.Semantic.DeepEqual(&oldObj.Spec, ps) {
+			return nil // Specs identical, allow update
+		}
 
-	// If already in the done state, the spec cannot be modified. Otherwise, only the status field can be modified.
-	tips := "Once the PipelineRun is complete, no updates are allowed"
-	if !oldObj.IsDone() {
-		old = old.DeepCopy()
-		old.Status = ps.Status
-		tips = "Once the PipelineRun has started, only status updates are allowed"
+		// Specs differ, this could be due to different defaults after upgrade
+		// Apply current defaults to old spec to normalize
+		oldCopy := oldObj.Spec.DeepCopy()
+		oldCopy.SetDefaults(ctx)
+
+		if equality.Semantic.DeepEqual(oldCopy, ps) {
+			return nil // Difference was only defaults, allow update
+		}
+
+		// Real spec changes detected, reject update
+		errs = errs.Also(apis.ErrInvalidValue("Once the PipelineRun is complete, no updates are allowed", ""))
+		return errs
 	}
+
+	// Handle started but not done case
+	old := oldObj.Spec.DeepCopy()
+	old.Status = ps.Status
 	if !equality.Semantic.DeepEqual(old, ps) {
-		errs = errs.Also(apis.ErrInvalidValue(tips, ""))
+		errs = errs.Also(apis.ErrInvalidValue("Once the PipelineRun has started, only status updates are allowed", ""))
 	}
 
-	return
+	return errs
 }
 
 func (ps *PipelineRunSpec) validatePipelineRunParameters(ctx context.Context) (errs *apis.FieldError) {

--- a/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1/provenance.go
+++ b/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1/provenance.go
@@ -41,6 +41,6 @@ type RefSource struct {
 
 	// EntryPoint identifies the entry point into the build. This is often a path to a
 	// build definition file and/or a target label within that file.
-	// Example: "task/git-clone/0.8/git-clone.yaml"
+	// Example: "task/git-clone/0.10/git-clone.yaml"
 	EntryPoint string `json:"entryPoint,omitempty"`
 }

--- a/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1/swagger.json
+++ b/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1/swagger.json
@@ -1194,7 +1194,7 @@
           }
         },
         "entryPoint": {
-          "description": "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.8/git-clone.yaml\"",
+          "description": "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.10/git-clone.yaml\"",
           "type": "string"
         },
         "uri": {

--- a/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1/task_validation.go
+++ b/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1/task_validation.go
@@ -445,8 +445,9 @@ func validateStep(ctx context.Context, s Step, names sets.String) (errs *apis.Fi
 	}
 
 	for j, vm := range s.VolumeMounts {
-		if strings.HasPrefix(vm.MountPath, "/tekton/") &&
-			!strings.HasPrefix(vm.MountPath, "/tekton/home") {
+		cleanMountPath := filepath.Clean(vm.MountPath)
+		if strings.HasPrefix(cleanMountPath, "/tekton/") &&
+			!strings.HasPrefix(cleanMountPath, "/tekton/home") {
 			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("volumeMount cannot be mounted under /tekton/ (volumeMount %q mounted at %q)", vm.Name, vm.MountPath), "mountPath").ViaFieldIndex("volumeMounts", j))
 		}
 		if strings.HasPrefix(vm.Name, "tekton-internal-") {

--- a/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1/taskrun_validation.go
+++ b/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1/taskrun_validation.go
@@ -125,29 +125,42 @@ func (ts *TaskRunSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 // ValidateUpdate validates the update of a TaskRunSpec
 func (ts *TaskRunSpec) ValidateUpdate(ctx context.Context) (errs *apis.FieldError) {
 	if !apis.IsInUpdate(ctx) {
-		return
+		return errs
 	}
 	oldObj, ok := apis.GetBaseline(ctx).(*TaskRun)
 	if !ok || oldObj == nil {
-		return
+		return errs
 	}
-	old := &oldObj.Spec
+	if oldObj.IsDone() {
+		// try comparing without any copying first
+		// this handles the common case where only finalizers changed
+		if equality.Semantic.DeepEqual(&oldObj.Spec, ts) {
+			return nil // Specs identical, allow update
+		}
 
-	// If already in the done state, the spec cannot be modified.
-	// Otherwise, only the status, statusMessage field can be modified.
-	tips := "Once the TaskRun is complete, no updates are allowed"
-	if !oldObj.IsDone() {
-		old = old.DeepCopy()
-		old.Status = ts.Status
-		old.StatusMessage = ts.StatusMessage
-		tips = "Once the TaskRun has started, only status and statusMessage updates are allowed"
+		// Specs differ, this could be due to different defaults after upgrade
+		// Apply current defaults to old spec to normalize
+		oldCopy := oldObj.Spec.DeepCopy()
+		oldCopy.SetDefaults(ctx)
+
+		if equality.Semantic.DeepEqual(oldCopy, ts) {
+			return nil // Difference was only defaults, allow update
+		}
+
+		// Real spec changes detected, reject update
+		errs = errs.Also(apis.ErrInvalidValue("Once the TaskRun is complete, no updates are allowed", ""))
+		return errs
 	}
 
+	// Handle started but not done case
+	old := oldObj.Spec.DeepCopy()
+	old.Status = ts.Status
+	old.StatusMessage = ts.StatusMessage
 	if !equality.Semantic.DeepEqual(old, ts) {
-		errs = errs.Also(apis.ErrInvalidValue(tips, ""))
+		errs = errs.Also(apis.ErrInvalidValue("Once the TaskRun has started, only status and statusMessage updates are allowed", ""))
 	}
 
-	return
+	return errs
 }
 
 // validateInlineParameters validates that any parameters called in the

--- a/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -713,7 +713,7 @@ func schema_pkg_apis_pipeline_v1beta1_ConfigSource(ref common.ReferenceCallback)
 					},
 					"entryPoint": {
 						SchemaProps: spec.SchemaProps{
-							Description: "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.8/git-clone.yaml\"",
+							Description: "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.10/git-clone.yaml\"",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -3168,7 +3168,7 @@ func schema_pkg_apis_pipeline_v1beta1_RefSource(ref common.ReferenceCallback) co
 					},
 					"entryPoint": {
 						SchemaProps: spec.SchemaProps{
-							Description: "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.8/git-clone.yaml\"",
+							Description: "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.10/git-clone.yaml\"",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -195,15 +195,7 @@ func (pt PipelineTask) Validate(ctx context.Context) (errs *apis.FieldError) {
 		NamespacedTaskKind: true,
 	}
 
-	if pt.OnError != "" {
-		errs = errs.Also(config.ValidateEnabledAPIFields(ctx, "OnError", config.BetaAPIFields))
-		if pt.OnError != PipelineTaskContinue && pt.OnError != PipelineTaskStopAndFail {
-			errs = errs.Also(apis.ErrInvalidValue(pt.OnError, "OnError", "PipelineTask OnError must be either \"continue\" or \"stopAndFail\""))
-		}
-		if pt.OnError == PipelineTaskContinue && pt.Retries > 0 {
-			errs = errs.Also(apis.ErrGeneric("PipelineTask OnError cannot be set to \"continue\" when Retries is greater than 0"))
-		}
-	}
+	errs = errs.Also(pt.ValidateOnError(ctx))
 
 	// Pipeline task having taskRef/taskSpec with APIVersion is classified as custom task
 	switch {
@@ -219,6 +211,20 @@ func (pt PipelineTask) Validate(ctx context.Context) (errs *apis.FieldError) {
 		errs = errs.Also(pt.validateTask(ctx))
 	}
 	return //nolint:nakedret
+}
+
+// ValidateOnError validates the OnError field of a PipelineTask
+func (pt PipelineTask) ValidateOnError(ctx context.Context) (errs *apis.FieldError) {
+	if pt.OnError != "" && !isParamRefs(string(pt.OnError)) {
+		errs = errs.Also(config.ValidateEnabledAPIFields(ctx, "OnError", config.BetaAPIFields))
+		if pt.OnError != PipelineTaskContinue && pt.OnError != PipelineTaskStopAndFail {
+			errs = errs.Also(apis.ErrInvalidValue(pt.OnError, "OnError", "PipelineTask OnError must be either \"continue\" or \"stopAndFail\""))
+		}
+		if pt.OnError == PipelineTaskContinue && pt.Retries > 0 {
+			errs = errs.Also(apis.ErrGeneric("PipelineTask OnError cannot be set to \"continue\" when Retries is greater than 0"))
+		}
+	}
+	return errs
 }
 
 // validateEnabledInlineSpec validates that pipelineSpec or taskSpec is allowed by checking
@@ -805,6 +811,10 @@ func findAndValidateResultRefsForMatrix(tasks []PipelineTask, taskMapping map[st
 func validateMatrixedPipelineTaskConsumed(expressions []string, taskMapping map[string]PipelineTask) (resultRefs []*ResultRef, errs *apis.FieldError) {
 	var filteredExpressions []string
 	for _, expression := range expressions {
+		// if it is not matrix result ref expression, skip
+		if !resultref.LooksLikeResultRef(expression) {
+			continue
+		}
 		// ie. "tasks.<pipelineTaskName>.results.<resultName>[*]"
 		subExpressions := strings.Split(expression, ".")
 		pipelineTask := subExpressions[1] // pipelineTaskName

--- a/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1/provenance.go
+++ b/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1/provenance.go
@@ -44,7 +44,7 @@ type RefSource struct {
 
 	// EntryPoint identifies the entry point into the build. This is often a path to a
 	// build definition file and/or a target label within that file.
-	// Example: "task/git-clone/0.8/git-clone.yaml"
+	// Example: "task/git-clone/0.10/git-clone.yaml"
 	EntryPoint string `json:"entryPoint,omitempty"`
 }
 
@@ -62,6 +62,6 @@ type ConfigSource struct {
 
 	// EntryPoint identifies the entry point into the build. This is often a path to a
 	// build definition file and/or a target label within that file.
-	// Example: "task/git-clone/0.8/git-clone.yaml"
+	// Example: "task/git-clone/0.10/git-clone.yaml"
 	EntryPoint string `json:"entryPoint,omitempty"`
 }

--- a/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1/swagger.json
@@ -307,7 +307,7 @@
           }
         },
         "entryPoint": {
-          "description": "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.8/git-clone.yaml\"",
+          "description": "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.10/git-clone.yaml\"",
           "type": "string"
         },
         "uri": {
@@ -1602,7 +1602,7 @@
           }
         },
         "entryPoint": {
-          "description": "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.8/git-clone.yaml\"",
+          "description": "EntryPoint identifies the entry point into the build. This is often a path to a build definition file and/or a target label within that file. Example: \"task/git-clone/0.10/git-clone.yaml\"",
           "type": "string"
         },
         "uri": {

--- a/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -434,8 +434,9 @@ func validateStep(ctx context.Context, s Step, names sets.String) (errs *apis.Fi
 	}
 
 	for j, vm := range s.VolumeMounts {
-		if strings.HasPrefix(vm.MountPath, "/tekton/") &&
-			!strings.HasPrefix(vm.MountPath, "/tekton/home") {
+		cleanMountPath := filepath.Clean(vm.MountPath)
+		if strings.HasPrefix(cleanMountPath, "/tekton/") &&
+			!strings.HasPrefix(cleanMountPath, "/tekton/home") {
 			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("volumeMount cannot be mounted under /tekton/ (volumeMount %q mounted at %q)", vm.Name, vm.MountPath), "mountPath").ViaFieldIndex("volumeMounts", j))
 		}
 		if strings.HasPrefix(vm.Name, "tekton-internal-") {

--- a/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1/taskrun_validation.go
+++ b/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1/taskrun_validation.go
@@ -125,29 +125,42 @@ func (ts *TaskRunSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 // ValidateUpdate validates the update of a TaskRunSpec
 func (ts *TaskRunSpec) ValidateUpdate(ctx context.Context) (errs *apis.FieldError) {
 	if !apis.IsInUpdate(ctx) {
-		return
+		return errs
 	}
 	oldObj, ok := apis.GetBaseline(ctx).(*TaskRun)
 	if !ok || oldObj == nil {
-		return
+		return errs
 	}
-	old := &oldObj.Spec
+	if oldObj.IsDone() {
+		// try comparing without any copying first
+		// this handles the common case where only finalizers changed
+		if equality.Semantic.DeepEqual(&oldObj.Spec, ts) {
+			return nil // Specs identical, allow update
+		}
 
-	// If already in the done state, the spec cannot be modified.
-	// Otherwise, only the status, statusMessage field can be modified.
-	tips := "Once the TaskRun is complete, no updates are allowed"
-	if !oldObj.IsDone() {
-		old = old.DeepCopy()
-		old.Status = ts.Status
-		old.StatusMessage = ts.StatusMessage
-		tips = "Once the TaskRun has started, only status and statusMessage updates are allowed"
+		// Specs differ, this could be due to different defaults after upgrade
+		// Apply current defaults to old spec to normalize
+		oldCopy := oldObj.Spec.DeepCopy()
+		oldCopy.SetDefaults(ctx)
+
+		if equality.Semantic.DeepEqual(oldCopy, ts) {
+			return nil // Difference was only defaults, allow update
+		}
+
+		// Real spec changes detected, reject update
+		errs = errs.Also(apis.ErrInvalidValue("Once the TaskRun is complete, no updates are allowed", ""))
+		return errs
 	}
 
+	// Handle started but not done case
+	old := oldObj.Spec.DeepCopy()
+	old.Status = ts.Status
+	old.StatusMessage = ts.StatusMessage
 	if !equality.Semantic.DeepEqual(old, ts) {
-		errs = errs.Also(apis.ErrInvalidValue(tips, ""))
+		errs = errs.Also(apis.ErrInvalidValue("Once the TaskRun has started, only status and statusMessage updates are allowed", ""))
 	}
 
-	return
+	return errs
 }
 
 // validateInlineParameters validates that any parameters called in the

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -305,8 +305,8 @@ github.com/stoewer/go-strcase
 ## explicit; go 1.17
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/assert/yaml
-# github.com/tektoncd/pipeline v1.0.0
-## explicit; go 1.23.0
+# github.com/tektoncd/pipeline v1.0.2
+## explicit; go 1.24.0
 github.com/tektoncd/pipeline/internal/artifactref
 github.com/tektoncd/pipeline/pkg/apis/config
 github.com/tektoncd/pipeline/pkg/apis/pipeline


### PR DESCRIPTION
Bumps `github.com/tektoncd/pipeline` from v1.0.0 to v1.0.1 to fix [CVE-2026-33211](https://nvd.nist.gov/vuln/detail/CVE-2026-33211) (CVSS 9.6, CWE-22 path traversal)
