### PR TITLE
chore: add AGENTS.md and AI skills for agentic workflows

### DIFF
--- a/.agents/skills/commit-message/SKILL.md
+++ b/.agents/skills/commit-message/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: commit-message
+description: >-
+  Create properly formatted conventional commit messages for
+  manual-approval-gate. Use when asked to "create a commit", "generate
+  commit message", "commit changes", or "make a commit". Applies component
+  scopes, line length validation, DCO Signed-off-by, and Assisted-by trailers.
+license: Apache-2.0
+metadata:
+  project: manual-approval-gate
+  allowed-tools: Read Grep Glob Bash(git diff:*) Bash(git log:*) Bash(git status)
+---
+
+# Conventional Commit Message Creation
+
+Create properly formatted conventional commit messages following Tekton
+community standards with line length validation and required trailers.
+
+## Format
+
+```text
+<type>(<scope>): <description>
+
+[optional body]
+
+Signed-off-by: <name> <email>
+Assisted-by: <model> (via <tool>)
+```
+
+## Workflow
+
+1. **Analyze changes**: Run `git status` and `git diff --staged` to understand modifications
+2. **Determine type and scope**: See tables below
+3. **Generate message**: Subject line ≤72 chars, body wrapped at 72 chars
+4. **Add trailers**: Signed-off-by (from git config) and Assisted-by
+5. **Confirm with user**: Display message and wait for approval before committing
+
+**CRITICAL**: Never commit without explicit user confirmation.
+
+## Type Selection
+
+| Type | When to use |
+|------|-------------|
+| `feat` | New features or capabilities |
+| `fix` | Bug fixes |
+| `docs` | Documentation only |
+| `refactor` | Code restructuring without behavior change |
+| `test` | Adding or updating tests |
+| `chore` | Maintenance (deps, CI, build) |
+| `build` | Build system or tooling changes (go version, Makefile) |
+| `ci` | Changes to .github/workflows/ or .tekton/ directory |
+
+## Scope Selection
+
+Use the affected component as scope:
+
+| Scope | When |
+|-------|------|
+| `controller` | Changes to `pkg/reconciler/approvaltask/` or `cmd/controller/` |
+| `webhook` | Changes to `pkg/reconciler/webhook/` or `cmd/webhook/` |
+| `cli` | Changes to `pkg/cli/` or `cmd/tkn-approvaltask/` |
+| `api` | Changes to `pkg/apis/` |
+| `config` | Changes to `config/kubernetes/` or `config/openshift/` |
+| `e2e` | Changes to `test/` |
+| `deps` | Dependency updates |
+
+## Line Length Rules
+
+- **Subject**: ≤72 characters (includes `type(scope): `)
+- **Body**: wrap at 72 characters per line
+- **Blank line** required between subject and body
+
+## Required Trailers
+
+### Signed-off-by
+
+Detect from git config:
+
+```bash
+git config user.name
+git config user.email
+```
+
+Format: `Signed-off-by: Name <email>`
+
+### Assisted-by
+
+Always include when AI assisted: `Assisted-by: <model> (via <tool>)`
+
+## Commit Execution
+
+Use heredoc for proper multi-line handling:
+
+```bash
+git commit -m "$(cat <<'EOF'
+type(scope): subject line
+
+Body text wrapped at 72 characters.
+
+Signed-off-by: Name <email>
+Assisted-by: Model (via Tool)
+EOF
+)"
+```

--- a/.agents/skills/running-tests/SKILL.md
+++ b/.agents/skills/running-tests/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: running-tests
+description: >-
+  Run unit tests, e2e tests, and golden-file CLI tests for
+  manual-approval-gate. Use when asked to "run tests", "test this change",
+  "verify tests pass", or when investigating test failures.
+license: Apache-2.0
+compatibility: Requires go; e2e requires docker, kind, ko, kubectl
+metadata:
+  project: manual-approval-gate
+  allowed-tools: Bash(go test:*) Bash(make:*) Read Grep Glob
+---
+
+# Running Tests
+
+manual-approval-gate has three test layers: unit tests, CLI golden-file
+tests, and end-to-end tests requiring a live cluster.
+
+## Unit Tests (fast, no cluster)
+
+```bash
+# All unit tests
+go test -v ./...
+
+# With race detector
+go test -v -race ./...
+
+# Single package
+go test -v ./pkg/reconciler/approvaltask/...
+
+# Specific test function
+go test -v -run TestReconcile ./pkg/reconciler/approvaltask/...
+```
+
+Key unit test files:
+
+| File | What it tests |
+|------|---------------|
+| `pkg/reconciler/approvaltask/utils_test.go` | Reconciler utility logic |
+| `pkg/cli/cmd/list/list_test.go` | List command (golden files) |
+| `pkg/cli/cmd/describe/describe_test.go` | Describe command |
+| `pkg/cli/cmd/approve/approve_test.go` | Approve command |
+| `pkg/cli/cmd/reject/reject_test.go` | Reject command |
+
+## CLI Golden-File Tests
+
+CLI commands use golden-file testing. Expected outputs live in
+`pkg/cli/cmd/*/testdata/*.golden`.
+
+To update golden files after intentional output changes:
+
+```bash
+go test -v -run TestList ./pkg/cli/cmd/list/... -update
+```
+
+The `-update` flag rewrites `.golden` files with actual output.
+
+## E2E Tests (requires Docker + Kind)
+
+The full e2e suite spins up a Kind cluster with Tekton Pipelines installed:
+
+```bash
+./test/e2e-test.sh
+```
+
+This script:
+1. Starts a local Docker registry
+2. Creates a Kind cluster (`test/kind.yaml`)
+3. Installs Tekton Pipelines from the latest release
+4. Deploys manual-approval-gate via `ko apply -f config/kubernetes`
+5. Runs controller e2e: `go test -v -count=1 -tags=e2e -timeout=20m ./test/e2e_test.go`
+6. Runs CLI e2e: `go test -v -count=1 -tags=e2e -timeout=20m ./test/cli/...`
+
+### Running e2e against an existing cluster
+
+If you already have a cluster with Tekton and the approval gate deployed:
+
+```bash
+go test -v -count=1 -tags=e2e -timeout=20m ./test/e2e_test.go
+go test -v -count=1 -tags=e2e -timeout=20m ./test/cli/...
+```
+
+### E2E test scenarios
+
+The e2e suite covers (`test/e2e_test.go`):
+- Approval flow (single approver)
+- Rejection flow
+- Group-based approvers
+- Timeout behavior
+- Multiple approvers with quorum
+
+## Makefile Shortcuts
+
+```bash
+make test-unit   # go test -v -race ./...
+make lint        # go vet ./...
+make fmt         # gofmt -l -w .
+```
+
+## Troubleshooting
+
+- **Tests hang**: Check if e2e tests are accidentally running without the
+  `e2e` build tag (they need a cluster)
+- **Golden file mismatch**: Run with `-update` flag, then `git diff` to
+  review changes before committing
+- **Webhook tests fail**: Ensure admission webhook certs are valid in
+  test fixtures

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,12 @@
 .idea
+.vscode/
+.DS_Store
+*.swp
+*.swo
+coverage.txt
+*.coverprofile
+*.test
+cover.out
+bin/
+_output/
+.agentready/

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,8 @@
+[general]
+# https://jorisroovers.github.io/gitlint/configuration/general_options/#regex-style-search
+regex-style-search=True
+
+# Dependabot tends to generate lines that exceed the default 80 char limit.
+[ignore-by-author-name]
+regex=dependabot
+ignore=all

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,115 @@
+# Manual Approval Gate
+
+Tekton Custom Task controller, validating webhook, and CLI (`tkn-approvaltask`)
+that adds manual approval checkpoints to Tekton PipelineRuns.
+
+---
+
+## Build & Test Commands
+
+```bash
+# Build
+go build -v ./...
+
+# Unit tests (no cluster needed)
+go test -v ./...
+
+# Single-file lint and type-check (fast, no cluster)
+go vet ./path/to/file.go
+go build ./path/to/package/...
+
+# Lint all
+make lint
+
+# Commit message lint (optional: pip install gitlint)
+make gitlint                              # lint last commit
+make gitlint GITLINT_COMMITS=origin/main..HEAD  # lint all commits on branch
+
+# E2E tests (requires Docker; spins up Kind + Tekton)
+./test/e2e-test.sh
+
+# Deploy to cluster (requires ko + cluster with Tekton Pipelines)
+make apply                     # Kubernetes
+make TARGET=openshift apply    # OpenShift
+
+# Code generation — after changing pkg/apis/ types
+hack/update-codegen.sh
+
+# Dependency update — after go.mod changes
+hack/update-deps.sh
+```
+
+E2E tests are tagged `//go:build e2e` and live in `test/`.
+
+---
+
+## Key Conventions
+
+1. **Vendored dependencies.** All builds use `-mod=vendor`. Run
+   `hack/update-deps.sh` after any `go.mod` change.
+
+2. **Knative controller runtime.** Reconcilers use `knative.dev/pkg`,
+   not `controller-runtime`. Status conditions use Knative APIs.
+
+3. **CustomRun reconciler pattern.** The controller watches Tekton `CustomRun`
+   resources that reference `ApprovalTask` (apiVersion
+   `openshift-pipelines.org/v1alpha1`). On each reconcile it creates or
+   updates a corresponding `ApprovalTask` CR and monitors approval state.
+
+4. **Validating webhook.** Admission endpoint `/approval-validation` enforces
+   that only listed approvers can modify their own input. Uses the Kubernetes
+   user identity from the admission request.
+
+5. **ko-based images.** Container images are built with `ko`; base image is
+   distroless. See `.ko.yaml` for overrides.
+
+6. **CLI is a tkn plugin.** The `tkn-approvaltask` binary provides `list`,
+   `describe`, `approve`, `reject` commands using dynamic client.
+
+---
+
+## Architecture
+
+```
+cmd/controller/                → CustomRun reconciler (main binary)
+cmd/webhook/                   → Validating admission webhook
+cmd/tkn-approvaltask/          → CLI plugin entry point
+pkg/apis/approvaltask/v1alpha1/→ CRD types, validation, deepcopy
+pkg/reconciler/approvaltask/   → Core reconciliation logic
+pkg/reconciler/webhook/        → Admission validation logic
+pkg/cli/                       → CLI commands, formatters, golden-file tests
+pkg/client/                    → Generated clientset, informers, listers
+config/kubernetes/             → Kubernetes manifests (CRD, RBAC, deployments)
+config/openshift/              → OpenShift-specific manifests
+test/                          → E2E tests and test data
+```
+
+---
+
+## PR Conventions
+
+- Commit messages should follow [Tekton community standards](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages); run `make gitlint` locally before push when gitlint is installed.
+- `go test -v ./...` must pass with zero failures.
+- `go vet ./...` must be clean.
+- Commits require `Signed-off-by` (DCO).
+
+---
+
+## Windows Checkout
+
+`CLAUDE.md` points to `AGENTS.md`, and `.claude/skills` points to `.agents/skills`.
+This works on Linux, macOS, and GitHub; on Windows, enable symlinks when cloning:
+
+```bash
+git clone -c core.symlinks=true https://github.com/openshift-pipelines/manual-approval-gate.git
+```
+
+Alternatively, set `core.symlinks=true` in your git config before checkout.
+
+---
+
+## Skills
+
+- **Commit messages**: Conventional commits with component scopes,
+  line length validation, DCO Signed-off-by, and Assisted-by trailers.
+- **Running tests**: Unit tests, e2e tests, and golden-file CLI tests.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,25 @@ M = $(shell printf "\033[34;1m🐱\033[0m")
 apply: ## Apply config to the current cluster
 	@echo "$(M) ko apply on config/$(TARGET)"
 	@ko apply -f config/$(TARGET)
+
+.PHONY: test-unit
+test-unit: ## Run unit tests
+	@echo "$(M) Running unit tests"
+	go test -v -race ./...
+
+.PHONY: lint
+lint: ## Run go vet
+	@echo "$(M) Running go vet"
+	go vet ./...
+
+.PHONY: fmt
+fmt: ## Run gofmt
+	@echo "$(M) Running gofmt"
+	@find . -name '*.go' -not -path './vendor/*' -not -path './third_party/*' | xargs gofmt -l -w
+
+GITLINT_COMMITS ?= HEAD
+
+.PHONY: gitlint
+gitlint: ## Lint commit messages (override range with GITLINT_COMMITS=origin/main..HEAD)
+	@echo "$(M) Running gitlint"
+	python3 -m gitlint.cli --commits $(GITLINT_COMMITS)


### PR DESCRIPTION
Prepare the manual-approval-gate repository for agentic workflows:
- AGENTS.md: agent-oriented context file covering build/test commands, key conventions, architecture, and PR rules
- CLAUDE.md: symlink to AGENTS.md
- .claude/skills/: commit-message and running-tests skills
- .agents/skills: symlink to .claude/skills for cross-agent discovery
- .gitlint: commit message linting config (conventional commits)
- Makefile: add test-unit, lint, fmt, and gitlint targets
- .gitignore: add missing patterns (coverage, IDE, build artifacts)

agentready score: 63.4/100 (Silver)