### PR TITLE
fix(cve): CVE-2026-39823 + 13 others - Go stdlib go1.25.8 → go1.25.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift-pipelines/manual-approval-gate
 
-go 1.25.8
+go 1.25.10
 
 require (
 	github.com/fatih/color v1.18.0


### PR DESCRIPTION
## CVE Details

| CVE | OSV ID | Summary |
|-----|--------|---------|
| CVE-2026-39823 | GO-2026-4982 | html/template meta content URL XSS bypass |
| CVE-2026-39826 | GO-2026-4980 | html/template escaper bypass XSS |
| CVE-2026-32289 | GO-2026-4865 | html/template JsBraceDepth context tracking XSS |
| CVE-2026-33814 | GO-2026-4918 | HTTP/2 infinite loop on bad SETTINGS_MAX_FRAME_SIZE |
| CVE-2026-39836 | GO-2026-4971 | net panic on NUL byte in Dial/LookupPort (Windows) |
| CVE-2026-33811 | GO-2026-4981 | net crash on long CNAME response |
| CVE-2026-39825 | GO-2026-4976 | net/http ReverseProxy query param forwarding |
| CVE-2026-42499 | GO-2026-4977 | net/mail quadratic string concat in consumePhrase |
| CVE-2026-39820 | GO-2026-4986 | net/mail quadratic string concat in consumeComment |
| CVE-2026-32282 | GO-2026-4864 | os TOCTOU root escape via Root.Chmod on Linux |
| CVE-2026-32283 | GO-2026-4870 | TLS 1.3 KeyUpdate connection retention |
| CVE-2026-32288 | GO-2026-4869 | archive/tar unbounded allocation (GNU sparse) |
| CVE-2026-32280 | GO-2026-4947 | crypto/x509 unexpected chain building work |
| CVE-2026-32281 | GO-2026-4946 | crypto/x509 inefficient policy validation |

## Fix Summary

Updated Go toolchain directive in `go.mod` from `go 1.25.8` to `go 1.25.10` — the minimum patch that fixes all 14 stdlib CVEs found by govulncheck.

- go1.25.9 fixes: CVE-2026-32280, CVE-2026-32281, CVE-2026-32282, CVE-2026-32283, CVE-2026-32288, CVE-2026-32289
- go1.25.10 adds: CVE-2026-33811, CVE-2026-33814, CVE-2026-39820, CVE-2026-39823, CVE-2026-39825, CVE-2026-39826, CVE-2026-39836, CVE-2026-42499

## Test Results

**Status:** ✅ PASSED

```
go test ./...
ok  github.com/openshift-pipelines/manual-approval-gate/pkg/cli/cmd/approve    0.021s
ok  github.com/openshift-pipelines/manual-approval-gate/pkg/cli/cmd/describe   0.022s
ok  github.com/openshift-pipelines/manual-approval-gate/pkg/cli/cmd/list       0.022s
ok  github.com/openshift-pipelines/manual-approval-gate/pkg/cli/cmd/reject     0.022s
ok  github.com/openshift-pipelines/manual-approval-gate/pkg/reconciler/approvaltask  0.023s
```

## Breaking Changes

None. The Go toolchain directive update is a minimum version requirement; the deployed binary will use whatever toolchain is available at build time. No API changes.

## Verification Steps

- [ ] `govulncheck ./...` no longer reports any stdlib CVEs
- [ ] `go test ./...` passes
- [ ] Container build succeeds with go1.25.10 toolchain

## Risk Assessment

**Risk: Low**
- Only change: `go 1.25.8` → `go 1.25.10` in go.mod
- Pure patch release — no API changes, only security fixes
- All tests pass

## Detection

Identified via `govulncheck` scan of `main` branch on 2026-06-02.