### PR TITLE
fix(cve): upgrade Go stdlib 1.25.8 → 1.25.11 (11 stdlib CVEs)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift-pipelines/manual-approval-gate
 
-go 1.25.8
+go 1.25.11
 
 require (
 	github.com/fatih/color v1.18.0


### PR DESCRIPTION
## CVE Details

Multiple Go stdlib vulnerabilities confirmed by `govulncheck` (all affecting go1.25.8, all fixed in go1.25.11):

| Advisory | Package | Summary | Fixed in |
|----------|---------|---------|---------|
| GO-2026-5039 | net/textproto | Arbitrary inputs in errors without escaping | go1.25.11 |
| GO-2026-5038 | mime | Quadratic complexity in WordDecoder.DecodeHeader | go1.25.11 |
| GO-2026-5037 | crypto/x509 | Inefficient candidate hostname parsing | go1.25.11 |
| GO-2026-4982 | html/template | Meta content URL escaping bypass causes XSS | go1.25.10 |
| GO-2026-4980 | html/template | Escaper bypass leads to XSS | go1.25.10 |
| GO-2026-4971 | net | Panic in Dial/LookupPort on NUL byte (Windows) | go1.25.10 |
| GO-2026-4947 | crypto/x509 | Unexpected work during chain building | go1.25.9 |
| GO-2026-4946 | crypto/x509 | Inefficient policy validation | go1.25.9 |
| GO-2026-4918 | net/http | — | go1.25.10 |
| GO-2026-4870 | crypto/tls | — | go1.25.9 |
| GO-2026-4865 | html/template | — | go1.25.9 |

## Fix Summary

Updated `go 1.25.8` → `go 1.25.11` in `go.mod`. This is a patch-level stdlib-only upgrade within the same minor line (go1.25.x). No module dependency versions changed.

## Test Results ✅

```
go mod tidy   → OK (no dependency changes)
go mod verify → all modules verified
go mod vendor → OK (no changes)
go test ./... → 5/5 test packages passed
```

Packages tested:
- `pkg/cli/cmd/approve` ✅
- `pkg/cli/cmd/describe` ✅
- `pkg/cli/cmd/list` ✅
- `pkg/cli/cmd/reject` ✅
- `pkg/reconciler/approvaltask` ✅

## Breaking Changes

None. This is a patch-level stdlib upgrade within the same minor line. No API changes.

## Verification Steps

- [ ] Review go.mod change (single-line: `go 1.25.8` → `go 1.25.11`)
- [ ] Confirm CI passes
- [ ] Run `govulncheck ./...` post-merge to verify stdlib CVEs are resolved

## Risk Assessment

**Low** — Patch-level Go toolchain bump (1.25.8 → 1.25.11) within the same minor series. No API or ABI changes. All existing tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)