### PR TITLE
fix(cve): upgrade Go stdlib go1.25.10 → go1.25.11 (3 stdlib CVEs)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift-pipelines/manual-approval-gate
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/fatih/color v1.19.0


### PR DESCRIPTION
## CVE Details

Three reachable stdlib vulnerabilities confirmed by \`govulncheck\` (all fixed in go1.25.11):

| CVE | Advisory | Package | Summary | Fixed in |
|-----|----------|---------|---------|---------|
| CVE-2026-42507 | GO-2026-5039 | net/textproto | Arbitrary inputs in errors without escaping | go1.25.11 |
| CVE-2026-42504 | GO-2026-5038 | mime | Quadratic complexity in WordDecoder.DecodeHeader | go1.25.11 |
| CVE-2026-27145 | GO-2026-5037 | crypto/x509 | Inefficient candidate hostname parsing | go1.25.11 |

**Note:** Two additional Tekton Pipelines advisories (GO-2026-4730, GO-2023-1901) in \`github.com/tektoncd/pipeline@v1.11.1\` have no upstream fix available yet and are not addressed here.

## Fix Summary

Updated \`go 1.25.10\` → \`go 1.25.11\` in \`go.mod\`. Patch-level stdlib-only upgrade within the same minor line (go1.25.x). No module dependency versions changed.

This supersedes PR #992 (same fix rebased on current main which is already at go1.25.10).

## Test Results ✅

```
go mod tidy   → OK (no dependency changes)
go mod verify → all modules verified
go mod vendor → OK (no changes to vendor/)
go test ./... → 5/5 packages passed
```

Packages tested:
- \`pkg/cli/cmd/approve\` ✅
- \`pkg/cli/cmd/describe\` ✅
- \`pkg/cli/cmd/list\` ✅
- \`pkg/cli/cmd/reject\` ✅
- \`pkg/reconciler/approvaltask\` ✅

## Breaking Changes

None. Patch-level Go toolchain bump (1.25.10 → 1.25.11) within the same minor series. No API or ABI changes.

## Verification Steps

- [ ] Review go.mod change (single-line: \`go 1.25.10\` → \`go 1.25.11\`)
- [ ] Confirm CI passes
- [ ] Run \`govulncheck ./...\` post-merge to verify stdlib CVEs are resolved
- [ ] Close superseded PR #992

## Risk Assessment

**Low** — Patch-level Go toolchain bump within the same minor series. No API changes. All existing tests pass.

## References

- https://pkg.go.dev/vuln/GO-2026-5039
- https://pkg.go.dev/vuln/GO-2026-5038
- https://pkg.go.dev/vuln/GO-2026-5037

🤖 Generated with [Claude Code](https://claude.com/claude-code)