### PR TITLE
fix(cve): CVE-2026-42507, CVE-2026-42504, CVE-2026-27145 - upgrade Go stdlib 1.25.10 → 1.25.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift-pipelines/manual-approval-gate
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/fatih/color v1.19.0


### PR DESCRIPTION
## CVE Details

| CVE | Go Advisory | Package | Severity | Fixed In |
|-----|-------------|---------|----------|---------|
| CVE-2026-42507 | GO-2026-5039 | net/textproto | High | go 1.25.11 |
| CVE-2026-42504 | GO-2026-5038 | mime | Medium | go 1.25.11 |
| CVE-2026-27145 | GO-2026-5037 | crypto/x509 | Medium | go 1.25.11 |

**CVE-2026-42507**: Arbitrary inputs are included in errors without any escaping in `net/textproto`. Could expose sensitive data or enable error-message injection.

**CVE-2026-42504**: Quadratic complexity in `mime.WordDecoder.DecodeHeader` — potential denial of service via crafted MIME headers.

**CVE-2026-27145**: Inefficient candidate hostname parsing in `crypto/x509` — potential denial of service via crafted certificate hostname lists.

## Fix Summary

Updated `go.mod` toolchain directive from `go 1.25.10` to `go 1.25.11`. This is the minimum safe patch version in the same minor line (1.25.x) that resolves all three vulnerabilities.

```diff
-go 1.25.10
+go 1.25.11
```

Steps applied:
- `go mod tidy` (no new dependencies added)
- `go mod verify` ✅ all modules verified
- `go mod vendor` (no vendor changes needed for stdlib bump)

## Test Results

**Status**: ✅ PASSED

**Command**: `GOTOOLCHAIN=go1.25.11 go test -mod=vendor ./...`

**Result**: `ok github.com/openshift-pipelines/manual-approval-gate/pkg/reconciler/approvaltask 0.023s`

All packages with test files passed. No test failures.

## Vulnerability Scan

**Tool**: govulncheck v1.4.0, -scan=package mode

**Before fix**: 3 stdlib CVEs detected (CVE-2026-42507, CVE-2026-42504, CVE-2026-27145)

**After fix**: All 3 stdlib CVEs resolved by toolchain upgrade to go 1.25.11

Note: Two additional findings (GO-2026-4730, GO-2023-1901) affect `github.com/tektoncd/pipeline@v1.11.1` with **no available upstream fix**. These require separate tracking.

## Breaking Changes

None. This is a patch-level Go toolchain update (1.25.10 → 1.25.11). No API changes.

## Jira References

No SRVKP Jira tickets found for these CVE IDs at time of fix. These CVEs were identified via govulncheck scan of the repository.

## Verification Steps

- [ ] Review `go.mod` diff: only `go 1.25.10` → `go 1.25.11`
- [ ] Confirm unit tests pass in CI
- [ ] Run `govulncheck -scan=package ./...` to verify CVEs are resolved

## Risk Assessment

**Risk: Low**

- Patch-level stdlib bump within same minor line
- No dependency graph changes
- No API surface changes
- Tests pass locally

---

⚠️ Note: Existing PRs #992 and #1007 also target this issue but only update `go.mod` without running `go mod tidy/verify/vendor`. This PR completes the full fix workflow with verification steps.

Signed-off-by: CVE Fixer Bot <cve-fixer@openshift-pipelines.org>
Co-Assisted-By: Claude Sonnet 4.6 <noreply@anthropic.com>