### PR TITLE
fix(cve): bump github.com/tektoncd/pipeline v1.9.2 → v1.9.3 (5 CVEs) [release-v0.8.0]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1
-	github.com/tektoncd/pipeline v1.9.2
+	github.com/tektoncd/pipeline v1.9.3
 	github.com/tektoncd/plumbing v0.0.0-20221005220331-b2ddcdddc5e7
 	go.uber.org/zap v1.27.1
 	gomodules.xyz/jsonpatch/v2 v2.5.0

--- a/go.sum
+++ b/go.sum
@@ -903,8 +903,8 @@ github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
-github.com/tektoncd/pipeline v1.9.2 h1:uKEt6CGLmkeKLdKIZnel0gn8lfQ1P7+398yystdBuHU=
-github.com/tektoncd/pipeline v1.9.2/go.mod h1:PTlIZ4Mhr8HZDx404O7spJtafiynetTMedCsXStjtHk=
+github.com/tektoncd/pipeline v1.9.3 h1:7Z+V2VX5wjz9LoNa16E1RbgH9mpYy5B1KnAMm3H0czc=
+github.com/tektoncd/pipeline v1.9.3/go.mod h1:pEruzPp4JM8JK8Nnnih46IPgdtxRPot/i9pUZo8lA9I=
 github.com/tektoncd/plumbing v0.0.0-20221005220331-b2ddcdddc5e7 h1:N9npo779eqTDXEjqcwVkwdS9rhHe+dkcfzhKp97zJfs=
 github.com/tektoncd/plumbing v0.0.0-20221005220331-b2ddcdddc5e7/go.mod h1:uJBaI0AL/kjPThiMYZcWRujEz7D401v643d6s/21GAg=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1/container_validation.go
+++ b/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1/container_validation.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"slices"
 	"strings"
@@ -197,8 +198,9 @@ func (s *Step) Validate(ctx context.Context) (errs *apis.FieldError) {
 	}
 
 	for j, vm := range s.VolumeMounts {
-		if strings.HasPrefix(vm.MountPath, "/tekton/") &&
-			!strings.HasPrefix(vm.MountPath, "/tekton/home") {
+		cleanMountPath := filepath.Clean(vm.MountPath)
+		if strings.HasPrefix(cleanMountPath, "/tekton/") &&
+			!strings.HasPrefix(cleanMountPath, "/tekton/home") {
 			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("volumeMount cannot be mounted under /tekton/ (volumeMount %q mounted at %q)", vm.Name, vm.MountPath), "mountPath").ViaFieldIndex("volumeMounts", j))
 		}
 		if strings.HasPrefix(vm.Name, "tekton-internal-") {

--- a/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/vendor/github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -434,8 +434,9 @@ func validateStep(ctx context.Context, s Step, names sets.String) (errs *apis.Fi
 	}
 
 	for j, vm := range s.VolumeMounts {
-		if strings.HasPrefix(vm.MountPath, "/tekton/") &&
-			!strings.HasPrefix(vm.MountPath, "/tekton/home") {
+		cleanMountPath := filepath.Clean(vm.MountPath)
+		if strings.HasPrefix(cleanMountPath, "/tekton/") &&
+			!strings.HasPrefix(cleanMountPath, "/tekton/home") {
 			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("volumeMount cannot be mounted under /tekton/ (volumeMount %q mounted at %q)", vm.Name, vm.MountPath), "mountPath").ViaFieldIndex("volumeMounts", j))
 		}
 		if strings.HasPrefix(vm.Name, "tekton-internal-") {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -303,8 +303,8 @@ github.com/spf13/pflag
 ## explicit; go 1.17
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/assert/yaml
-# github.com/tektoncd/pipeline v1.9.2
-## explicit; go 1.24.0
+# github.com/tektoncd/pipeline v1.9.3
+## explicit; go 1.24.13
 github.com/tektoncd/pipeline/internal/artifactref
 github.com/tektoncd/pipeline/pkg/apis/config
 github.com/tektoncd/pipeline/pkg/apis/pipeline


### PR DESCRIPTION
## CVE Details

Bumps `github.com/tektoncd/pipeline` from **v1.9.2** → **v1.9.3** to resolve 5 vulnerabilities confirmed present by govulncheck on branch `release-v0.8.0`.

| CVE | Go Advisory | Severity | Description |
|-----|-------------|----------|-------------|
| CVE-2026-40938 | GO-2026-5272 | High | Git Resolver Unsanitized Revision Parameter — git Argument Injection Leading to RCE |
| CVE-2026-40161 | GO-2026-5711 | High | Git resolver API mode leaks system-configured API token to user-controlled serverURL |
| CVE-2026-40923 | GO-2026-5643 | Medium | VolumeMount path restriction bypass via missing filepath.Clean in /tekton/ check |
| CVE-2026-40924 | GO-2026-5486 | Medium | HTTP Resolver Unbounded Response Body Read — DoS via Memory Exhaustion |
| CVE-2026-25542 | GO-2026-5630 | Medium | VerificationPolicy regex pattern bypass via substring matching |

## Fix Summary

- `go get github.com/tektoncd/pipeline@v1.9.3` (minimum safe patch in same minor line)
- `go mod tidy && go mod verify && go mod vendor` — all passed ✅
- Vendor diff: updated `container_validation.go`, `task_validation.go`, `vendor/modules.txt`

## Test Results

```
go test ./...
ok  github.com/openshift-pipelines/manual-approval-gate/pkg/reconciler/approvaltask  0.023s
ok  github.com/openshift-pipelines/manual-approval-gate/pkg/cli/...  PASS
```
✅ All tests pass

## Remaining (no upstream fix)

After this update, govulncheck reports 2 remaining issues with **Fixed in: N/A**:
- GO-2026-4730 / CVE-2026-33022: Tekton Pipelines controller panic via long resolver name — no upstream patch yet
- GO-2023-1901 / CVE-2023-37264: Pipelines do not validate child UIDs — no upstream patch yet

These cannot be addressed until upstream releases a fix.

## Breaking Changes

None — this is a patch release (v1.9.2 → v1.9.3) within the same minor.

## Jira References

SRVKP-11722, SRVKP-11723, SRVKP-11741, [SRVKP-11742](https://redhat.atlassian.net/browse/SRVKP-11742) (CVE-2026-40938 — pipelines-1.20/1.21)
SRVKP-11652, SRVKP-11653, SRVKP-11671, [SRVKP-11672](https://redhat.atlassian.net/browse/SRVKP-11672) (CVE-2026-40161 — pipelines-1.20/1.21)

## Verification Steps

- [ ] `govulncheck ./...` — GO-2026-5272/5711/5643/5486/5630 should be gone
- [ ] `go test ./...` — all pass
- [ ] `go build ./...` — builds clean
- [ ] CI passes

## Risk Assessment

**Low** — patch-only bump within same minor series (v1.9.x). No breaking API changes. Tests pass.