### PR TITLE
ci: bump Go version 1.25 → 1.26

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: 1.25
+        go-version-file: go.mod
     - uses: actions/cache@v6
       with:
         path: |
@@ -39,11 +39,11 @@ jobs:
       KO_DOCKER_REPO: registry.local:5000/knative
 
     steps:
+    - uses: actions/checkout@v7
     - uses: actions/setup-go@v6
       with:
-        go-version: 1.25
+        go-version-file: go.mod
     - uses: imjasonh/setup-ko@v0.10
-    - uses: actions/checkout@v7
     - uses: actions/cache@v6
       with:
         path: |
@@ -69,10 +69,10 @@ jobs:
       contents: read
 
     steps:
+    - uses: actions/checkout@v7
     - uses: actions/setup-go@v6
       with:
-        go-version: 1.25
-    - uses: actions/checkout@v7
+        go-version-file: go.mod
     - uses: actions/cache@v6
       with:
         path: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift-pipelines/manual-approval-gate
 
-go 1.25.11
+go 1.26
 
 require (
 	github.com/fatih/color v1.19.0


### PR DESCRIPTION
A transitive dependency requires Go >= 1.26. Update the go directive in go.mod and the setup-go version in all CI workflow jobs to satisfy the requirement.

Assisted-by: Claude Opus 4.6 (via Cursor)