### PR TITLE
[release-v0.6.0] Security: Fix CVE-2026-42505 (crypto/tls)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift-pipelines/manual-approval-gate
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/fatih/color v1.18.0


### PR DESCRIPTION
## Summary

This PR fixes **CVE-2026-42505** (GO-2026-5856) by upgrading the Go toolchain from `go1.25.11` to `go1.25.12` in `go.mod`.

### CVE Details
- **CVE ID**: CVE-2026-42505
- **Go Vuln ID**: GO-2026-5856
- **Severity**: Medium
- **Package**: `crypto/tls` (Go standard library)
- **Vulnerable versions**: go1.25.x < go1.25.12
- **Fixed version**: go1.25.12
- **Description**: Handshakes using Encrypted Client Hello (ECH) could be de-anonymized by a passive network observer due to pre-shared key identity disclosure in the unencrypted client hello.
- **Reference**: https://pkg.go.dev/vuln/GO-2026-5856

### Changes
- Bumped `go 1.25.11` → `go 1.25.12` in `go.mod`
- Ran `go mod tidy && go mod verify && go mod vendor`

### Vulnerability Scan
- **Tool**: govulncheck (golang.org/x/vuln/cmd/govulncheck)
- **Toolchain**: `GOTOOLCHAIN=go1.25.12`
- **Result**: CVE-2026-42505 confirmed present before fix; no longer reported after upgrade

### Test Results
**Status**: ✅ All tests passed
**Command**: `GOTOOLCHAIN=go1.25.12 go test ./...`
**Summary**: Go tests passed (5 packages OK — pkg/cli/cmd/approve, describe, list, reject; pkg/reconciler/approvaltask)

### Risk Assessment
**Low** — Pure Go toolchain version bump (patch release within 1.25.x). No API or behavioral changes to application code.

### Breaking Changes
None — patch release within the same minor line (1.25.11 → 1.25.12).

---
🤖 Generated by CVE Fixer Workflow

```release-note
Security fix: update Go stdlib from go1.25.11 to go1.25.12 to address CVE-2026-42505 (crypto/tls ECH privacy leak)
```