### PR TITLE
ci(.github/workflows): enable Codecov coverage reporting

### DIFF
--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -1,0 +1,35 @@
+on:
+  push:
+    branches: [ main ]
+
+name: Go coverage
+
+permissions:
+  contents: read
+
+jobs:
+  go-coverage:
+    name: Go coverage
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      - name: Generate coverage
+        run: go test -coverprofile=coverage.out -covermode=atomic ./...
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v6
+        with:
+          files: coverage.out
+          flags: unit-tests
+          use_oidc: true
+          fail_ci_if_error: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+    patch:
+      default: false
+
+ignore:
+- "pkg/apis/approvaltask/v1alpha1/zz_generated.deepcopy.go"
+- "**/fake/**"
+- "hack/**"
+- "test/**"
+- "pkg/client/**"
+- "vendor/**"


### PR DESCRIPTION
Add Codecov coverage reporting triggered only on push. Upload coverage to Codecov via OIDC.

Assisted-by: Claude Sonnet 5 (via Claude Code)