### PR TITLE
Security: Fix CVE-2026-63209 (klauspost/compress v1.18.6 → v1.18.7)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
-	github.com/klauspost/compress v1.18.6 // indirect
+	github.com/klauspost/compress v1.18.7 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
-github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
-github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/klauspost/compress v1.18.7 h1:aUyZsS4kH3QTKurYhAOwAHxllVPnOthb3vPfnF1Ehjw=
+github.com/klauspost/compress v1.18.7/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -184,7 +184,7 @@ github.com/json-iterator/go
 # github.com/kelseyhightower/envconfig v1.4.0
 ## explicit
 github.com/kelseyhightower/envconfig
-# github.com/klauspost/compress v1.18.6
+# github.com/klauspost/compress v1.18.7
 ## explicit; go 1.24
 github.com/klauspost/compress
 github.com/klauspost/compress/fse


### PR DESCRIPTION
## CVE Details

- **CVE ID**: CVE-2026-63209
- **GHSA**: GHSA-259r-337f-4rfw
- **Go Advisory**: GO-2026-5841
- **Severity**: High
- **CVSS v3.1 Score**: 7.5 (AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H)
- **Affected Package**: `github.com/klauspost/compress/s2`
- **Affected Versions**: v1.16.0 – v1.18.6
- **Fixed Version**: v1.18.7

## Description

Integer overflow / out-of-bounds write in `s2.NewDict`. A specially crafted dictionary with a uvarint-encoded repeat value exceeding `MaxInt64` causes an overflowed negative repeat value triggering out-of-bounds memory access via `unsafe.Pointer` arithmetic in `Dict.Encode()`, crashing the process with SIGSEGV.

## Fix Summary

- Upgraded `github.com/klauspost/compress` from `v1.18.6` → `v1.18.7`
- Ran `go mod tidy && go mod verify && go mod vendor`

## Test Results ✅

```
ok  github.com/openshift-pipelines/manual-approval-gate/pkg/cli/cmd/approve    0.027s
ok  github.com/openshift-pipelines/manual-approval-gate/pkg/cli/cmd/describe   0.024s
ok  github.com/openshift-pipelines/manual-approval-gate/pkg/cli/cmd/list       0.023s
ok  github.com/openshift-pipelines/manual-approval-gate/pkg/cli/cmd/reject     0.028s
ok  github.com/openshift-pipelines/manual-approval-gate/pkg/reconciler/approvaltask  0.021s
```

All unit tests pass.

## Breaking Changes

None. v1.18.6 → v1.18.7 is a patch version upgrade with no API changes.

## Risk Assessment

**Low** — patch-only update within same minor line (v1.18.x), no API changes, all tests pass.

## Jira References

No existing Jira ticket for CVE-2026-63209 on Manual Approval component. Fix identified via automated govulncheck scan.

## Verification Steps for Reviewers

- [ ] Confirm `vendor/github.com/klauspost/compress` is at v1.18.7
- [ ] Run `go test ./...` — all tests pass
- [ ] Run `govulncheck ./...` — GO-2026-5841 not reported

---

*Generated by CVE Fixer automation. Component: Manual Approval Gate. Branch: main.*